### PR TITLE
Fix typo in menu bar

### DIFF
--- a/menus/atom-solidity.cson
+++ b/menus/atom-solidity.cson
@@ -21,7 +21,7 @@
           'command': 'eth-interface:build'
         }
         {
-          'label': 'Togggle view'
+          'label': 'Toggle view'
           'command': 'eth-interface:toggle'
         }
         {


### PR DESCRIPTION
`Togggle` should be `Toggle`